### PR TITLE
Fix docker volume conflict with vite in node_modules

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,8 @@ services:
     ports:
       - 3130:3130
     volumes:
-      - ./:/app
+      - .:/app
+      - node_modules:/app/node_modules
+
+volumes:
+  node_modules:


### PR DESCRIPTION
Creating a shared volume with ".:/app" also shares the node_modules between the host and the container. This is problematic because vite creates a cache folder ".vite" in the node_modules with docker's root permissions. Thus, vite on the host machine fails to launch as it tries to access this cache. The new volume isolates the node_modules of the container from the host's, avoiding the problem altogether.